### PR TITLE
Add mutate method before changing alpha of image container background…

### DIFF
--- a/loupe-library/src/main/java/com/igreenwood/loupe/Loupe.kt
+++ b/loupe-library/src/main/java/com/igreenwood/loupe/Loupe.kt
@@ -850,7 +850,7 @@ class Loupe(var imageView: ImageView, var container: ViewGroup) : View.OnTouchLi
 
     private fun changeBackgroundAlpha(amount: Float) {
         val newAlpha = ((1.0f - amount) * 255).roundToInt()
-        container.background.alpha = newAlpha
+        container.background.mutate().alpha = newAlpha
     }
 
     fun setDragToDismissDistance(distance: Int) {


### PR DESCRIPTION
Due to the specific of Drawable class in Android it shares single state when load from one resource. 
Loupe have method `changeBackgroundAlpha()` that change alpha of background drawable. And if I set background as some color and use it in another places, method `changeBackgroundAlpha()` will change share state in all places.
As mentioned in this [article](https://android-developers.googleblog.com/2009/05/drawable-mutations.html), if you want change drawable properties, should call `mutate()` to avoid all this drawable shared state problems.

Thanks for library, I'm thinking to use it my project)