### PR TITLE
Add flag useDragToDismiss to enable/disable drag to dismiss gesture

### DIFF
--- a/loupe-library/src/main/java/com/igreenwood/loupe/Loupe.kt
+++ b/loupe-library/src/main/java/com/igreenwood/loupe/Loupe.kt
@@ -57,6 +57,8 @@ class Loupe(imageView: ImageView, container: ViewGroup) : View.OnTouchListener,
     var maxZoom = DEFAULT_MAX_ZOOM
     // use fling gesture for dismiss
     var useFlingToDismissGesture = true
+    // flag to enable or disable drag to dismiss
+    var useDragToDismiss = true
     // duration millis for dismiss animation
     var dismissAnimationDuration = DEFAULT_ANIM_DURATION
     // duration millis for restore animation
@@ -174,7 +176,7 @@ class Loupe(imageView: ImageView, container: ViewGroup) : View.OnTouchListener,
 
                 if (scale > minScale) {
                     processScroll(distanceX, distanceY)
-                } else if (scale == minScale) {
+                } else if (useDragToDismiss && scale == minScale) {
                     processDrag(distanceY)
                 }
                 return true


### PR DESCRIPTION
In my app, we have a screen that we want only to allow the zoom feature and not have the drag to dismiss action. 

One way I found to control it is adding the flag `useDragToDismiss` similar to the `useFlingToDismissGesture` where we can control at the library init and verify if it's on in the `onGestureListener.onScroll` callback right before call``processDrag`.