### PR TITLE
fix: Loupe shouldn't crash when container ViewGroup has no background

### DIFF
--- a/loupe-library/src/main/java/com/igreenwood/loupe/Loupe.kt
+++ b/loupe-library/src/main/java/com/igreenwood/loupe/Loupe.kt
@@ -223,7 +223,7 @@ class Loupe(imageView: ImageView, container: ViewGroup) : View.OnTouchListener,
 
     init {
         container.apply {
-            background.alpha = 255
+            background?.alpha = 255
             setOnTouchListener(this@Loupe)
             addOnLayoutChangeListener(this@Loupe)
             scaleGestureDetector = ScaleGestureDetector(context, onScaleGestureListener)
@@ -315,7 +315,7 @@ class Loupe(imageView: ImageView, container: ViewGroup) : View.OnTouchListener,
             } else {
                 setDragToDismissDistance(DEFAULT_DRAG_DISMISS_DISTANCE_IN_DP)
             }
-            container.background.alpha = 255
+            container.background?.alpha = 255
             setTransform()
             postInvalidate()
         }
@@ -903,7 +903,7 @@ class Loupe(imageView: ImageView, container: ViewGroup) : View.OnTouchListener,
     private fun changeBackgroundAlpha(amount: Float) {
         val container = containerRef.get() ?: return
         val newAlpha = ((1.0f - amount) * 255).roundToInt()
-        container.background.mutate().alpha = newAlpha
+        container.background?.mutate()?.alpha = newAlpha
     }
 
     fun setDragToDismissDistance(distance: Int) {


### PR DESCRIPTION
Currently Loupe crashes if the container viewgroup for the "loupenized" image has no background set. 

To reproduce this:

* Go to layout file `item_image.xml` in loupe sample (https://github.com/igreenwood/loupe/blob/master/loupe-sample/src/main/res/layout/item_image.xml)
* Remove line `android:background="@color/black_alpha_87"` in container ViewGroup (see below)
* Start sample app and click on any image
* -> app will crash 

This PR will fix this issue


```
<?xml version="1.0" encoding="utf-8"?>
<layout xmlns:android="http://schemas.android.com/apk/res/android">
    <FrameLayout
        android:id="@+id/container"
        android:layout_width="match_parent"
        android:layout_height="match_parent"
        android:background="@color/black_alpha_87"  <!-- REMOVE THIS LINE TO REPRODUCE THE BUG IN LOUPE-SAMPLE--> 
        >
        <ImageView
            android:id="@+id/image"
            android:layout_width="match_parent"
            android:layout_height="match_parent" />
    </FrameLayout>
</layout>
```
